### PR TITLE
added ethereum call to sdk

### DIFF
--- a/go/sdk/contract.go
+++ b/go/sdk/contract.go
@@ -8,20 +8,23 @@ type ContractInstance interface {
 }
 
 type BaseContract struct {
-	State   StateSdk
-	Service ServiceSdk
-	Address AddressSdk
+	State    StateSdk
+	Service  ServiceSdk
+	Ethereum EthereumSdk
+	Address  AddressSdk
 }
 
 func NewBaseContract(
 	state StateSdk,
 	service ServiceSdk,
+	ethereum EthereumSdk,
 	address AddressSdk,
 ) *BaseContract {
 
 	return &BaseContract{
-		State:   state,
-		Service: service,
-		Address: address,
+		State:    state,
+		Service:  service,
+		Ethereum: ethereum,
+		Address:  address,
 	}
 }

--- a/go/sdk/sdk.go
+++ b/go/sdk/sdk.go
@@ -32,6 +32,10 @@ type ServiceSdk interface {
 	CallMethod(ctx Context, serviceName string, methodName string, args ...interface{}) ([]interface{}, error)
 }
 
+type EthereumSdk interface {
+	CallMethod(ctx Context, contractAddress string, jsonAbi string, methodName string, out interface{}, args ...interface{}) error
+}
+
 type AddressSdk interface {
 	ValidateAddress(ctx Context, address Ripmd160Sha256) error
 	GetSignerAddress(ctx Context) (Ripmd160Sha256, error)


### PR DESCRIPTION
for now it makes the following assumptions:
ABI is supplied as JSON (as it is in web3 or the parsing input of go-ethereum, which are both the same format)
contract address is the 0xHEX of the contract in ethereum
out is a pointer to a strongly typed struct of the output as defined in the ABI
args are the input params (as defined in the ABI)
args (params) need to be documented as for how to pass in int, string and so on, examples are required once we see this works end-to-end in the orbs-network-go repo. to illustrate, ints must be passed as big.NewInt() in go, its possible to later have the processor bullet-proof that
